### PR TITLE
Add existing network policies

### DIFF
--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rasa
 description: A Rasa Pro Helm chart for Kubernetes
 type: application
-version: 0.1.21
+version: 0.1.22
 appVersion: "1.16.0"
 home: https://rasa.com
 sources:

--- a/charts/rasa/README.md
+++ b/charts/rasa/README.md
@@ -222,9 +222,19 @@ rasaProServices:
 | hostNetwork | bool | `false` | hostNetwork controls whether the pod may use the node network namespace |
 | imagePullSecrets | list | `[]` | imagePullSecrets is used for private repository pull secrets |
 | nameOverride | string | `""` | nameOverride overrides name of the app |
+| networkPolicy.actionServerAllowEgressIngress.enabled | bool | `false` |  |
 | networkPolicy.denyAll | bool | `false` | Specifies whether to apply denyAll network policy |
-| networkPolicy.enabled | bool | `false` | Specifies whether to enable network policies |
+| networkPolicy.enabled | bool | `true` | Specifies whether to enable network policies |
 | networkPolicy.nodeCIDR | list | `[]` | Allow for traffic from a given CIDR - it's required in order to make kubelet able to run live and readiness probes |
+| networkPolicy.postgresqlAllowEgressIngress.enabled | bool | `false` |  |
+| networkPolicy.postgresqlAllowEgressIngress.matchLabels | object | `{}` |  |
+| networkPolicy.postgresqlAllowEgressIngress.port | int | `5432` |  |
+| networkPolicy.rabbitmqAllowEgressIngress.enabled | bool | `false` |  |
+| networkPolicy.rabbitmqAllowEgressIngress.matchLabels | object | `{}` |  |
+| networkPolicy.rabbitmqAllowEgressIngress.port | int | `5672` |  |
+| networkPolicy.redisAllowEgressIngress.enabled | bool | `false` |  |
+| networkPolicy.redisAllowEgressIngress.matchLabels | object | `{}` |  |
+| networkPolicy.redisAllowEgressIngress.port | int | `6379` |  |
 | podLabels | object | `{}` | podLabels defines labels to add to all Rasa pod(s) |
 | rasa.additionalArgs | list | `[]` | rasa.additionalArgs adds additional arguments to the default args |
 | rasa.additionalContainers | list | `[]` | rasa.additionalContainers allows to specify additional containers for the Rasa Deployment |

--- a/charts/rasa/templates/network-policy/allow-action-server-ingress-egress.yaml
+++ b/charts/rasa/templates/network-policy/allow-action-server-ingress-egress.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.actionServerAllowEgressIngress.enabled }}
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rasa.fullname" . }}-allow-action-server-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rasa.name" . }}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: action-server
+    ports:
+    - protocol: TCP
+      port: {{ .Values.actionServer.service.port }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rasa.fullname" . }}-allow-action-server-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: action-server
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ include "rasa.name" . }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.actionServer.service.port }}
+{{- end }}

--- a/charts/rasa/templates/network-policy/allow-dns-access.yaml
+++ b/charts/rasa/templates/network-policy/allow-dns-access.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
-  name: allow-dns-access
+  name: {{ include "rasa.fullname" . }}-allow-dns-access
   namespace: {{ .Release.Namespace }}
 spec:
   podSelector:

--- a/charts/rasa/templates/network-policy/allow-postgresql-egress-ingress.yaml
+++ b/charts/rasa/templates/network-policy/allow-postgresql-egress-ingress.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.postgresqlAllowEgressIngress.enabled }}
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rasa.fullname" . }}-allow-postgresql-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rasa.name" . }}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          {{- .Values.networkPolicy.postgresqlAllowEgressIngress.matchLabels | toYaml | nindent 10 }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.networkPolicy.postgresqlAllowEgressIngress.port }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rasa.fullname" . }}-allow-postgresql-ingress
+spec:
+  podSelector:
+    matchLabels:
+      {{- .Values.networkPolicy.postgresqlAllowEgressIngress.matchLabels | toYaml | nindent 6 }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ include "rasa.name" . }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.networkPolicy.postgresqlAllowEgressIngress.port }}
+{{- end }}

--- a/charts/rasa/templates/network-policy/allow-rabbitmq-egress-ingress.yaml
+++ b/charts/rasa/templates/network-policy/allow-rabbitmq-egress-ingress.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.rabbitmqAllowEgressIngress.enabled }}
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rasa.fullname" . }}-allow-rabbitmq-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rasa.name" . }}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          {{- .Values.networkPolicy.rabbitmqAllowEgressIngress.matchLabels | toYaml | nindent 10 }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.networkPolicy.rabbitmqAllowEgressIngress.port }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rasa.fullname" . }}-allow-rabbitmq-ingress
+spec:
+  podSelector:
+    matchLabels:
+      {{- .Values.networkPolicy.rabbitmqAllowEgressIngress.matchLabels | toYaml | nindent 6 }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ include "rasa.name" . }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.networkPolicy.rabbitmqAllowEgressIngress.port }}
+{{- end }}

--- a/charts/rasa/templates/network-policy/allow-redis-egress-ingress.yaml
+++ b/charts/rasa/templates/network-policy/allow-redis-egress-ingress.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.redisAllowEgressIngress.enabled }}
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rasa.fullname" . }}-allow-redis-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rasa.name" . }}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          {{- .Values.networkPolicy.redisAllowEgressIngress.matchLabels | toYaml | nindent 10 }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.networkPolicy.redisAllowEgressIngress.port }}
+---
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rasa.fullname" . }}-allow-redis-ingress
+spec:
+  podSelector:
+    matchLabels:
+      {{- .Values.networkPolicy.redisAllowEgressIngress.matchLabels | toYaml | nindent 6 }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: {{ include "rasa.name" . }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.networkPolicy.redisAllowEgressIngress.port }}
+{{- end }}

--- a/charts/rasa/templates/network-policy/ingress-egress-from-kubelet.yaml
+++ b/charts/rasa/templates/network-policy/ingress-egress-from-kubelet.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
-  name: ingress-egress-from-kubelet-to-rasa
+  name: {{ include "rasa.fullname" . }}-ingress-egress-from-kubelet-to-rasa
   namespace: {{ .Release.Namespace }}
 spec:
   policyTypes:
@@ -24,7 +24,7 @@ spec:
 apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
-  name: ingress-egress-from-kubelet-to-rasa-pro-services
+  name: {{ include "rasa.fullname" . }}-ingress-egress-from-kubelet-to-rasa-pro-services
   namespace: {{ .Release.Namespace }}
 spec:
   policyTypes:

--- a/charts/rasa/templates/network-policy/rabbitmq-https-kubernetes-api.yaml
+++ b/charts/rasa/templates/network-policy/rabbitmq-https-kubernetes-api.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.networkPolicy.enabled .Values.networkPolicy.rabbitmqAllowEgressIngress.enabled }}
+apiVersion: {{ template "networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rasa.fullname" . }}-rabbitmq-https-kubernetes-api
+spec:
+  podSelector:
+    matchLabels:
+      {{- .Values.networkPolicy.rabbitmqAllowEgressIngress.matchLabels | toYaml | nindent 6 }}
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+      - protocol: TCP
+        port: 8443
+      - protocol: TCP
+        port: 443
+---
+{{- end }}

--- a/charts/rasa/values.yaml
+++ b/charts/rasa/values.yaml
@@ -82,11 +82,11 @@ rasa:
       # input channels
       ## See: https://rasa.com/docs/rasa/messaging-and-voice-channels
       additionalChannelCredentials: {}
-      #  rest:
-      #  facebook:
-      #    verify: "rasa"
-      #    secret: "<SECRET>"
-      #    page-access-token: "<PAGE-ACCESS-TOKEN>"
+        # rest:
+        # facebook:
+        #   verify: "rasa"
+        #   secret: "<SECRET>"
+        #   page-access-token: "<PAGE-ACCESS-TOKEN>"
 
     # See: https://rasa.com/docs/rasa/telemetry/telemetry/
     telemetry:
@@ -598,13 +598,30 @@ rasaProServices:
 # Network policy settings
 networkPolicy:
   # -- Specifies whether to enable network policies
-  enabled: false
+  enabled: true
   # -- Specifies whether to apply denyAll network policy
   denyAll: false
   # -- Allow for traffic from a given CIDR - it's required in order to make kubelet able to run live and readiness probes
   nodeCIDR: []
     # - ipBlock:
     #     cidr: 0.0.0.0/0
+  rabbitmqAllowEgressIngress:
+    enabled: false
+    matchLabels: {}
+      # app.kubernetes.io/name: rabbitmq
+    port: 5672
+  postgresqlAllowEgressIngress:
+    enabled: false
+    matchLabels: {}
+      # app.kubernetes.io/name: postgresql
+    port: 5432
+  actionServerAllowEgressIngress:
+    enabled: false
+  redisAllowEgressIngress:
+    enabled: false
+    matchLabels: {}
+      # app.kubernetes.io/name: redis
+    port: 6379
 
 # Defines global settings for all resources
 global:


### PR DESCRIPTION
- Policies that existed in old Rasa Helm Charts.
- Add the ability to add `matchLabels` for external services.