### PR TITLE
[INFRA-883] Reorganize API keys and images

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -44,13 +44,14 @@ spec:
           title: Studio repository URL
           default: '{{repl (ConfigOptionEquals "image_registry" "internal_registry") | ternary "registry.rasa.com/proxy/studio-dragon/europe-west3-docker.pkg.dev/rasa-releases/studio/" ""}}'
           help_text: URL of your repository for Studio, without an image name
-          when: '{{repl ConfigOptionEquals "image_registry" "external_registry"}}'
+          when: '{{repl and (ConfigOptionEquals "image_registry" "external_registry") (ConfigOptionNotEquals "rasa_platform_deploy" "rasa_pro") }}'
         - name: studio_image_tag
           type: text
           title: Studio version
           default: "1.2.0"
           help_text: Specifies image tag for Studio
-        - name: rasa_config_image
+          when: 'repl{{ ConfigOptionNotEquals `rasa_platform_deploy` `rasa_pro` }}'
+        - name: rasa_pro_repository
           type: text
           title: Rasa Pro repository URL
           default: '{{repl (ConfigOptionEquals "image_registry" "internal_registry") | ternary "registry.rasa.com/proxy/studio-dragon/europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro" ""}}'
@@ -60,23 +61,23 @@ spec:
             regex:
               pattern: '[^\/]$'
               message: You have `/` at the end of your image URL. Please remove the `/` from the end in in format `repository/image_name`.
-        - name: docker_image_tag
+        - name: rasa_pro_image_tag
           type: text
           title: Rasa Pro version
           default: "3.8.0"
-          help_text: Rasa Plus docker image to be used for training
-          when: 'repl{{ ConfigOptionNotEquals `rasa_platform_deploy` `rasa_pro` }}'
+          help_text: Specifies image tag for Rasa Pro. This image is used for deployment or for training
         - name: rasa_config_file
           type: text
           title: Rasa Pro config file
           default: ""
           help_text: base64 encoded Rasa Pro config file. This is required if you want to use a custom Rasa Pro config file and override the default one.
+          when: 'repl{{ ConfigOptionNotEquals `rasa_platform_deploy` `rasa_pro` }}'
         - name: model_services_repository
           type: text
           title: Model services repository URL
           default: '{{repl (ConfigOptionEquals "image_registry" "internal_registry") | ternary "registry.rasa.com/proxy/studio-dragon/europe-west3-docker.pkg.dev/rasa-releases/model-training-and-running-services/" ""}}'
           help_text: URL of your repository for Model services, without an image name
-          when: '{{repl ConfigOptionEquals "image_registry" "external_registry"}}'
+          when: '{{repl and (ConfigOptionEquals "image_registry" "external_registry") (ConfigOptionNotEquals "rasa_platform_deploy" "rasa_pro") }}'
         - name: model_service_image_tag
           type: text
           title: Model services version
@@ -826,11 +827,6 @@ spec:
       title: Rasa Pro
       when: 'repl{{ ConfigOptionNotEquals `rasa_platform_deploy` `studio` }}'
       items:
-        - name: rasa_pro_image_tag
-          type: text
-          title: Rasa Pro version
-          default: "3.8.0-latest"
-          help_text: Specifies image tag for Rasa Pro
         - name: rasa_auth_token
           type: text
           title: Rasa Auth Token

--- a/replicated/rasa-pro-chart.yaml
+++ b/replicated/rasa-pro-chart.yaml
@@ -22,7 +22,7 @@ spec:
       secretKey: "RASA_PRO_LICENCE"
     rasa:
       image:
-        repository: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.rasa.com" }}/{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/europe-west3-docker.pkg.dev/rasa-releases/rasa-pro/rasa-pro" ) }}'
+        repository: '{{repl ConfigOption "rasa_pro_repository" }}'
         tag: '{{repl ConfigOption "rasa_pro_image_tag" }}'
       settings:
         enableApi: repl{{ eq (ConfigOption "rasa_enable_api") "1"}}
@@ -201,6 +201,16 @@ spec:
       enabled: true
 
   optionalValues:
+    - when: '{{repl ConfigOptionEquals "image_registry" "internal_registry"}}'
+      recursiveMerge: true
+      values:
+        imagePullSecrets:
+          - name: '{{repl ImagePullSecretName }}'
+    - when: '{{repl ConfigOptionEquals "image_registry" "external_registry"}}'
+      recursiveMerge: true
+      values:
+        imagePullSecrets:
+          - name: '{{repl ConfigOption "image_pull_secrets" }}'
     - when: '{{repl ConfigOptionEquals "rasa_platform_deploy" "rasa_platform"}}'
       recursiveMerge: true
       values:

--- a/replicated/studio-chart.yaml
+++ b/replicated/studio-chart.yaml
@@ -71,7 +71,7 @@ spec:
         KEYCLOAK_CLIENT_ID:
           value: '{{repl ConfigOption "keycloak_client_id" }}'
         DOCKER_IMAGE_TAG:
-          value: '{{repl ConfigOption "rasa_config_image" }}:{{repl ConfigOption "docker_image_tag" }}'
+          value: '{{repl ConfigOption "rasa_pro_repository" }}:{{repl ConfigOption "rasa_pro_image_tag" }}'
         RASA_CONFIG_FILE:
           value: '{{repl ConfigOption "rasa_config_file" }}'
       migration:


### PR DESCRIPTION
[Jira task](https://rasahq.atlassian.net/browse/INFRA-883)

API keys and images are different for `Rasa platform`, `Studio` and `Rasa Pro` deployment.
`Use Default Registry` and `Use Private Registry` show different inputs.
The Details are described in the task.