### PR TITLE
[INFRA-888] Use rasa-events as default kafka topic in rasa pro

### DIFF
--- a/replicated/rasa-pro-chart.yaml
+++ b/replicated/rasa-pro-chart.yaml
@@ -46,7 +46,7 @@ spec:
             enabled: repl{{ eq (ConfigOption "rasa_kafka_event_broker") "1"}}
             type: '{{repl ConfigOption "rasa_event_broker_type" }}'
             security_protocol: '{{repl ConfigOption "kafka_security_protocol" }}'
-            topic: '{{repl ConfigOption "rasa_core_events_topic" }}'
+            topic: '{{repl ConfigOption "kafka_topic" }}'
             url: '{{repl ConfigOption "kafka_broker" }}'
             sasl_username: '{{repl ConfigOption "kafka_username" }}'
             sasl_password: '{{repl ConfigOption "kafka_password" }}'
@@ -187,7 +187,7 @@ spec:
         KAFKA_SSL_CA_LOCATION:
           value: '{{repl ConfigOption "kafka_ca_file" }}'
         KAFKA_TOPIC:
-          value: '{{repl ConfigOption "rasa_core_events_topic" }}'
+          value: '{{repl ConfigOption "kafka_topic" }}'
         LOGGING_LEVEL:
           value: '{{repl ConfigOption "rasa_pro_services_logging_level" }}'
         RASA_ANALYTICS_DB_URL:


### PR DESCRIPTION
[Jira task](https://rasahq.atlassian.net/browse/INFRA-888)
Use `rasa-events` as default kafka topic for:
- Event Broker's kafka topic
- Rasa Pro Service's `KAFKA_TOPIC` environment variable