### PR TITLE
rename securitycontext to containersecuritycontext in the rasa-pro chart

### DIFF
--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rasa
 description: A Rasa Pro Helm chart for Kubernetes
 type: application
-version: 1.1.0
+version: 1.1.1
 home: https://rasa.com
 sources:
   - https://github.com/RasaHQ/rasa-helm-charts/tree/main/charts/rasa

--- a/charts/rasa/README.md
+++ b/charts/rasa/README.md
@@ -128,7 +128,7 @@ rasaProServices:
 | actionServer.readinessProbe.timeoutSeconds | int | `5` | readinessProbe.timeoutSeconds defines number of seconds after which the probe times out |
 | actionServer.replicaCount | int | `1` | actionServer.replicaCount specifies number of replicas |
 | actionServer.resources | object | `{}` | actionServer.resources specifies the resources limits and requests |
-| actionServer.securityContext | object | `{"enabled":true}` | actionServer.securityContext defines security context that allows you to overwrite the pod-level security context |
+| actionServer.containerSecurityContext | object | `{"enabled":true}` | actionServer.containerSecurityContext defines security context that allows you to overwrite the container-level security context |
 | actionServer.service | object | `{"annotations":{},"externalTrafficPolicy":"Cluster","loadBalancerIP":null,"nodePort":null,"port":5055,"targetPort":5055,"type":"ClusterIP"}` | actionServer.service define service for Action Server |
 | actionServer.service.annotations | object | `{}` | service.annotations defines annotations to add to the service |
 | actionServer.service.externalTrafficPolicy | string | `"Cluster"` | service.externalTrafficPolicy enables client source IP preservation # Ref: http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip |
@@ -192,7 +192,7 @@ rasaProServices:
 | duckling.readinessProbe.timeoutSeconds | int | `5` | readinessProbe.timeoutSeconds defines number of seconds after which the probe times out |
 | duckling.replicaCount | int | `1` | duckling.replicaCount specifies number of replicas |
 | duckling.resources | object | `{}` | duckling.resources specifies the resources limits and requests |
-| duckling.securityContext | object | `{"enabled":true}` | duckling.securityContext defines security context that allows you to overwrite the pod-level security context |
+| duckling.containerSecurityContext | object | `{"enabled":true}` | duckling.containerSecurityContext defines security context that allows you to overwrite the container-level security context |
 | duckling.service | object | `{"annotations":{},"externalTrafficPolicy":"Cluster","loadBalancerIP":null,"nodePort":null,"port":8000,"targetPort":8000,"type":"ClusterIP"}` | duckling.service define service for Duckling |
 | duckling.service.annotations | object | `{}` | service.annotations defines annotations to add to the service |
 | duckling.service.externalTrafficPolicy | string | `"Cluster"` | service.externalTrafficPolicy enables client source IP preservation # Ref: http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip |
@@ -264,7 +264,7 @@ rasaProServices:
 | rasa.readinessProbe.timeoutSeconds | int | `5` | readinessProbe.timeoutSeconds defines number of seconds after which the probe times out |
 | rasa.replicaCount | int | `1` | rasa.replicaCount specifies number of replicas |
 | rasa.resources | object | `{}` | rasa.resources specifies the resources limits and requests |
-| rasa.securityContext | object | `{"enabled":true}` | rasa.securityContext defines security context that allows you to overwrite the pod-level security context |
+| rasa.containerSecurityContext | object | `{"enabled":true}` | rasa.containerSecurityContext defines security context that allows you to overwrite the container-level security context |
 | rasa.service | object | `{"annotations":{},"externalTrafficPolicy":"Cluster","loadBalancerIP":null,"nodePort":null,"port":5005,"targetPort":5005,"type":"ClusterIP"}` | rasa.service define service for Rasa OSS/Plus |
 | rasa.service.annotations | object | `{}` | service.annotations defines annotations to add to the service |
 | rasa.service.externalTrafficPolicy | string | `"Cluster"` | service.externalTrafficPolicy enables client source IP preservation # Ref: http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip |
@@ -346,7 +346,7 @@ rasaProServices:
 | rasaProServices.readinessProbe.timeoutSeconds | int | `5` | readinessProbe.timeoutSeconds defines number of seconds after which the probe times out |
 | rasaProServices.replicaCount | int | `1` | rasaProServices.replicaCount specifies number of replicas |
 | rasaProServices.resources | object | `{}` | rasaProServices.resources specifies the resources limits and requests |
-| rasaProServices.securityContext | object | `{"enabled":true}` | rasaProServices.securityContext defines security context that allows you to overwrite the pod-level security context |
+| rasaProServices.containerSecurityContext | object | `{"enabled":true}` | rasaProServices.containerSecurityContext defines security context that allows you to overwrite the container-level security context |
 | rasaProServices.service | object | `{"annotations":{},"port":8732,"targetPort":8732,"type":"ClusterIP"}` | rasaProServices.service define service for Rasa OSS/Plus |
 | rasaProServices.service.annotations | object | `{}` | service.annotations defines annotations to add to the service |
 | rasaProServices.service.port | int | `8732` | service.port is used to specify service port |

--- a/charts/rasa/templates/action-server/deployment.yaml
+++ b/charts/rasa/templates/action-server/deployment.yaml
@@ -56,9 +56,9 @@ spec:
       {{- end }}
       containers:
         - name: action-server
-          {{- if .Values.actionServer.securityContext.enabled }}
+          {{- if .Values.actionServer.containerSecurityContext.enabled }}
           securityContext:
-            {{- omit .Values.actionServer.securityContext "enabled" | toYaml | nindent 12 }}
+            {{- omit .Values.actionServer.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           image: "{{ .Values.actionServer.image.repository }}:{{ .Values.actionServer.image.tag }}"
           imagePullPolicy: {{ .Values.actionServer.image.pullPolicy }}

--- a/charts/rasa/templates/duckling/deployment.yaml
+++ b/charts/rasa/templates/duckling/deployment.yaml
@@ -56,9 +56,9 @@ spec:
       {{- end }}
       containers:
         - name: duckling
-          {{- if .Values.duckling.securityContext.enabled }}
+          {{- if .Values.duckling.containerSecurityContext.enabled }}
           securityContext:
-            {{- omit .Values.duckling.securityContext "enabled" | toYaml | nindent 12 }}
+            {{- omit .Values.duckling.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           image: "{{ .Values.duckling.image.repository }}:{{ .Values.duckling.image.tag }}"
           imagePullPolicy: {{ .Values.duckling.image.pullPolicy }}

--- a/charts/rasa/templates/rasa-pro-services/deployment.yaml
+++ b/charts/rasa/templates/rasa-pro-services/deployment.yaml
@@ -54,9 +54,9 @@ spec:
       {{- end }}
       containers:
         - name: rasa-pro-services
-          {{- if .Values.rasaProServices.securityContext.enabled }}
+          {{- if .Values.rasaProServices.containerSecurityContext.enabled }}
           securityContext:
-            {{- omit .Values.rasaProServices.securityContext "enabled" | toYaml | nindent 12 }}
+            {{- omit .Values.rasaProServices.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           image: "{{ .Values.rasaProServices.image.repository }}:{{ .Values.rasaProServices.image.tag }}"
           imagePullPolicy: {{ .Values.rasaProServices.image.pullPolicy }}

--- a/charts/rasa/templates/rasa/deployment.yaml
+++ b/charts/rasa/templates/rasa/deployment.yaml
@@ -61,9 +61,9 @@ spec:
       {{- end }}
       containers:
         - name: rasa
-          {{- if .Values.rasa.securityContext.enabled }}
+          {{- if .Values.rasa.containerSecurityContext.enabled }}
           securityContext:
-            {{- omit .Values.rasa.securityContext "enabled" | toYaml | nindent 12 }}
+            {{- omit .Values.rasa.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           image: "{{ .Values.rasa.image.repository }}:{{ .Values.rasa.image.tag }}"
           imagePullPolicy: {{ .Values.rasa.image.pullPolicy }}

--- a/charts/rasa/values.yaml
+++ b/charts/rasa/values.yaml
@@ -230,19 +230,13 @@ rasa:
     enabled: true
     # fsGroup: 2000
 
-  # -- rasa.securityContext defines security context that allows you to overwrite the pod-level security context
-  securityContext:
+  # -- rasa.containerSecurityContext defines security context that allows you to overwrite the container-level security context
+  containerSecurityContext:
     enabled: true
-    # privileged: false
     # allowPrivilegeEscalation: false
     # capabilities:
     #   drop:
     #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
-    # seccompProfile:
-    #   type: RuntimeDefault
 
   # -- rasa.service define service for Rasa OSS/Plus
   service:
@@ -486,19 +480,14 @@ rasaProServices:
     enabled: true
     # fsGroup: 2000
 
-  # -- rasaProServices.securityContext defines security context that allows you to overwrite the pod-level security context
-  securityContext:
+  # -- rasaProServices.containerSecurityContext defines security context that allows you to overwrite the container-level security context
+  containerSecurityContext:
     enabled: true
     # privileged: false
     # allowPrivilegeEscalation: false
     # capabilities:
     #   drop:
     #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
-    # seccompProfile:
-    #   type: RuntimeDefault
 
   # -- rasaProServices.service define service for Rasa OSS/Plus
   service:
@@ -740,19 +729,14 @@ duckling:
     enabled: true
     # fsGroup: 2000
 
-  # -- duckling.securityContext defines security context that allows you to overwrite the pod-level security context
-  securityContext:
+  # -- duckling.containerSecurityContext defines security context that allows you to overwrite the container-level security context
+  containerSecurityContext:
     enabled: true
     # privileged: false
     # allowPrivilegeEscalation: false
     # capabilities:
     #   drop:
     #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
-    # seccompProfile:
-    #   type: RuntimeDefault
 
   # -- duckling.service define service for Duckling
   service:
@@ -980,8 +964,8 @@ actionServer:
     enabled: true
     # fsGroup: 2000
 
-  # -- actionServer.securityContext defines security context that allows you to overwrite the pod-level security context
-  securityContext:
+  # -- actionServer.containerSecurityContext defines security context that allows you to overwrite the container-level security context
+  containerSecurityContext:
     enabled: true
     # privileged: false
     # allowPrivilegeEscalation: false


### PR DESCRIPTION
This PR renames `securityContext` to `containerSecurityContext` for better clarity.