### PR TITLE
Add the ability to expose Kafka externally to be consumed by services outside the cluster

### DIFF
--- a/replicated/config.yaml
+++ b/replicated/config.yaml
@@ -72,6 +72,7 @@ spec:
           default: ""
           help_text: base64 encoded Rasa Pro config file. This is required if you want to use a custom Rasa Pro config file and override the default one.
           when: 'repl{{ ConfigOptionNotEquals `rasa_platform_deploy` `rasa_pro` }}'
+          hidden: true
         - name: model_services_repository
           type: text
           title: Model services repository URL
@@ -81,7 +82,7 @@ spec:
         - name: model_service_image_tag
           type: text
           title: Model services version
-          default: "3.3.2"
+          default: "3.3.2-latest"
           help_text: Specifies image tag for Model Service
         - name: mrs_nginx_proxy
           type: text
@@ -893,7 +894,7 @@ spec:
       - name: rasa_pro_services_image_tag
         type: text
         title: Rasa Pro Analytics version
-        default: "3.2.3-latest"
+        default: "3.3.2-latest"
         help_text: Specifies image tag for Rasa Pro Analytics
         when: '{{repl ConfigOptionEquals "deploy_analytics" "1"}}'
       - name: rasa_pro_services_logging_level
@@ -1013,7 +1014,7 @@ spec:
         - name: postgresql_image_tag
           type: text
           hidden: true
-          default: 16.2.0-debian-12-r8
+          default: 16.4.0-debian-12-r8
           help_text: Postgesql version used in embedded database
     - name: Redis
       description: >
@@ -1049,6 +1050,12 @@ spec:
               title: Embedded Kafka
             - name: external_kafka
               title: External Kafka
+        - name: expose_kafka
+          type: bool
+          title: Expose Kafka outside the cluster.
+          default: "0"
+          when: '{{repl ConfigOptionEquals "kafka_type" "embedded_kafka"}}'
+          help_text: Enable this if you want to expose Kafka externally through DNS. Use `<ingress dns hostname>:30002` to connect to it.
         - name: kafka_broker
           type: text
           title: Kafka broker address

--- a/replicated/embeddedcluster.yaml
+++ b/replicated/embeddedcluster.yaml
@@ -3,7 +3,7 @@ kind: Config
 metadata:
   name: embedded-cluster-config
 spec:
-  version: 1.6.0+k8s-1.29
+  version: 1.12.0+k8s-1.29
   unsupportedOverrides:
     k0s: |
       config:
@@ -20,7 +20,7 @@ spec:
       - name: ingress-nginx
         chartname: ingress-nginx/ingress-nginx
         namespace: ingress-nginx
-        version: "4.10.1"
+        version: "4.11.1"
         values: |
           controller:
             service:

--- a/replicated/ingress-nginx-chart.yaml
+++ b/replicated/ingress-nginx-chart.yaml
@@ -6,7 +6,7 @@ spec:
   exclude: 'repl{{ ConfigOptionNotEquals `install_nginx` `on_kubernetes` }}'
   chart:
     name: ingress-nginx
-    chartVersion: 4.10.1
+    chartVersion: 4.11.1
   
   releaseName: ingress-nginx
   namespace: ingress-nginx
@@ -20,7 +20,7 @@ spec:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.rasa.com"}}'
         # image: ingress-nginx/controller
         image: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/europe-west3-docker.pkg.dev/rasa-releases/dependencies" ) }}/controller'
-        tag: "v1.10.1"
+        tag: "v1.11.1"
         digest: ""
         digestChroot: ""
       admissionWebhooks:

--- a/replicated/kafka-chart.yaml
+++ b/replicated/kafka-chart.yaml
@@ -6,7 +6,7 @@ spec:
   exclude: 'repl{{ ConfigOptionEquals `kafka_type` `external_kafka` }}'
   chart:
     name: kafka
-    chartVersion: 29.3.5
+    chartVersion: 30.0.4
   
   releaseName: kafka
   namespace: kafka
@@ -16,7 +16,7 @@ spec:
     image:
       registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.rasa.com"}}'
       repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/europe-west3-docker.pkg.dev/rasa-releases/dependencies" ) }}/kafka'
-      tag: 3.7.1-debian-12-r0
+      tag: 3.8.0-debian-12-r3
       digest: ""
       pullPolicy: IfNotPresent
       pullSecrets:
@@ -72,13 +72,13 @@ spec:
     rbac:
       create: true
     externalAccess:
-      enabled: true
+      enabled: repl{{ eq (ConfigOption "expose_kafka") "1"}}
       autoDiscovery:
         enabled: true
         image:
           registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.rasa.com"}}'
           repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/europe-west3-docker.pkg.dev/rasa-releases/dependencies" ) }}/kubectl'
-          tag: 1.30.2-debian-12-r1
+          tag: 1.31.0-debian-12-r0
           pullSecrets:
             - '{{repl ImagePullSecretName }}'
       controller:

--- a/replicated/postgresql-chart.yaml
+++ b/replicated/postgresql-chart.yaml
@@ -6,7 +6,7 @@ spec:
   exclude: 'repl{{ ConfigOptionEquals `postgres_type` `external_postgres` }}'
   chart:
     name: postgresql
-    chartVersion: 13.4.0
+    chartVersion: 15.5.29
   
   releaseName: postgresql
   namespace: postgresql

--- a/replicated/redis-chart.yaml
+++ b/replicated/redis-chart.yaml
@@ -6,7 +6,7 @@ spec:
   exclude: 'repl{{ ConfigOptionEquals `rasa_platform_deploy` `studio` }}'
   chart:
     name: redis
-    chartVersion: 19.1.1
+    chartVersion: 20.0.3
 
   releaseName: redis
   namespace: redis
@@ -19,7 +19,7 @@ spec:
     image:
       registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.rasa.com"}}'
       repository: '{{repl HasLocalRegistry | ternary LocalRegistryNamespace (print "proxy/" (LicenseFieldValue "appSlug") "/europe-west3-docker.pkg.dev/rasa-releases/dependencies" ) }}/redis'
-      tag: 7.2.5-debian-12-r2
+      tag: 7.4.0-debian-12-r2
       digest: ""
       pullPolicy: IfNotPresent
       pullSecrets:


### PR DESCRIPTION
- Add the option to expose Kafka outside the cluster
- Update embedded cluster version
- Update Kafka helm chart version
- Update Kafka images versions
- Update Postgresql helm chart version
- Update Postgresql image version
- Update Ingress helm chart version
- Update Ingress images version
- Update Redis helm chart version
- Update Redis image version
- Update Rasa images version
- Remove Rasa config environment variable from Studio