### PR TITLE
fix(rasa-pro-services): fix broken secret references for database fields

### DIFF
--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rasa
 description: A Rasa Pro Helm chart for Kubernetes
 type: application
-version: 2.0.3
+version: 2.0.4
 home: https://rasa.com
 sources:
   - https://github.com/RasaHQ/rasa-helm-charts/tree/main/charts/rasa

--- a/charts/rasa/README.md
+++ b/charts/rasa/README.md
@@ -2,7 +2,7 @@
 
 A Rasa Pro Helm chart for Kubernetes
 
-![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.4](https://img.shields.io/badge/Version-2.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -18,7 +18,7 @@ You can install the chart from either the OCI registry or the GitHub Helm reposi
 To install the chart with the release name `my-release`:
 
 ```console
-helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.0.3
+helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.0.4
 ```
 
 ### Option 2: Install from GitHub Helm Repository
@@ -33,7 +33,7 @@ helm repo update
 Then install the chart:
 
 ```console
-helm install my-release rasa/rasa --version 2.0.3
+helm install my-release rasa/rasa --version 2.0.4
 ```
 
 ## Uninstalling the Chart
@@ -53,13 +53,13 @@ You can pull the chart from either source:
 ### From OCI Registry:
 
 ```console
-helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.0.3
+helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.0.4
 ```
 
 ### From GitHub Helm Repository:
 
 ```console
-helm pull rasa/rasa --version 2.0.3
+helm pull rasa/rasa --version 2.0.4
 ```
 
 ## General Configuration
@@ -92,6 +92,40 @@ rasa:
 rasaProServices:
   enabled: false
 ```
+
+### Rasa Pro Services Database Configuration
+
+The `rasaProServices.database` section configures the analytics data lake connection. There are two ways to provide the database URL.
+
+**Plain value:**
+
+```yaml
+rasaProServices:
+  database:
+    url: "postgresql://user:password@host:5432/dbname"
+```
+
+**From an existing secret** (recommended for production):
+
+Create a Kubernetes secret containing the database URL:
+
+```console
+kubectl create secret generic my-db-secret \
+  --from-literal=analyticsDbUrl="postgresql://user:password@host:5432/dbname"
+```
+
+Then reference it in your values:
+
+```yaml
+rasaProServices:
+  database:
+    urlExistingSecretName: my-db-secret
+    urlExistingSecretKey: analyticsDbUrl
+```
+
+When `urlExistingSecretName` is set it takes precedence over `url`.
+
+For AWS RDS IAM authentication, use `database.enableAwsRdsIam: true` together with `hostname`, `usernameExistingSecretName`/`username`, `databaseNameExistingSecretName`/`databaseName`, `port`, and `sslMode` instead of the URL fields.
 
 ### Use MiniO instead of S3
 
@@ -474,14 +508,14 @@ See the [Rasa endpoints documentation](https://rasa.com/docs/pro/build/configuri
 | rasaProServices.autoscaling.minReplicas | int | autoscaling.minReplicas specifies the minimum number of replicas | `1` |
 | rasaProServices.autoscaling.targetCPUUtilizationPercentage | int | autoscaling.targetCPUUtilizationPercentage specifies the target CPU/Memory utilization percentage | `80` |
 | rasaProServices.containerSecurityContext | object | rasaProServices.containerSecurityContext defines security context that allows you to overwrite the container-level security context | `{"enabled":true}` |
-| rasaProServices.database.databaseName | string | database.databaseName specifies the database name for the data lake to store analytics data in. Required if enableAwsRdsIam is true. It can be a plain string or a secret reference:   databaseName:     secretName: my-secret     secretKey: analyticsDbName | `""` |
+| rasaProServices.database.databaseName | string | database.databaseName specifies the database name for the data lake to store analytics data in. Required if enableAwsRdsIam is true. To pass the database name from an existing secret instead, leave this empty and set databaseNameExistingSecretName and databaseNameExistingSecretKey:   databaseNameExistingSecretName: my-secret   databaseNameExistingSecretKey: analyticsDbName | `""` |
 | rasaProServices.database.enableAwsRdsIam | bool | database.enableAwsRdsIam specifies whether to use AWS RDS IAM authentication for the Rasa Pro Services container. | `false` |
 | rasaProServices.database.hostname | string | database.hostname specifies the hostname of the data lake to store analytics data in. Required if enableAwsRdsIam is true. | `""` |
 | rasaProServices.database.port | string | database.port specifies the port for the data lake to store analytics data in. Required if enableAwsRdsIam is true. | `"5432"` |
 | rasaProServices.database.sslCaLocation | string | database.sslCaLocation specifies the SSL CA location for the data lake to store analytics data in. Required if sslMode is verify-full. | `""` |
 | rasaProServices.database.sslMode | string | database.sslMode specifies the SSL mode for the data lake to store analytics data in. Required if enableAwsRdsIam is true. | `""` |
-| rasaProServices.database.url | string | database.url specifies the URL of the data lake to store analytics data in. Use `hostname` if you use IAM authentication. It can be a plain string or a secret reference:   url:     secretName: my-secret     secretKey: analyticsDbUrl | `""` |
-| rasaProServices.database.username | string | database.username specifies the username for the data lake to store analytics data in. Required if enableAwsRdsIam is true. It can be a plain string or a secret reference:   username:     secretName: my-secret     secretKey: analyticsDbUsername | `""` |
+| rasaProServices.database.url | string | database.url specifies the URL of the data lake to store analytics data in. Use `hostname` if you use IAM authentication. To pass the URL from an existing secret instead, leave this empty and set urlExistingSecretName and urlExistingSecretKey:   urlExistingSecretName: my-secret   urlExistingSecretKey: analyticsDbUrl | `""` |
+| rasaProServices.database.username | string | database.username specifies the username for the data lake to store analytics data in. Required if enableAwsRdsIam is true. To pass the username from an existing secret instead, leave this empty and set usernameExistingSecretName and usernameExistingSecretKey:   usernameExistingSecretName: my-secret   usernameExistingSecretKey: analyticsDbUsername | `""` |
 | rasaProServices.enabled | bool | rasaProServices.enabled enables Rasa Pro Services deployment | `true` |
 | rasaProServices.envFrom | list | rasaProServices.envFrom is used to add environment variables from ConfigMap or Secret | `[]` |
 | rasaProServices.image.pullPolicy | string | image.pullPolicy specifies image pull policy | `"IfNotPresent"` |

--- a/charts/rasa/README.md.gotmpl
+++ b/charts/rasa/README.md.gotmpl
@@ -92,6 +92,40 @@ rasaProServices:
   enabled: false
 ```
 
+### Rasa Pro Services Database Configuration
+
+The `rasaProServices.database` section configures the analytics data lake connection. There are two ways to provide the database URL.
+
+**Plain value:**
+
+```yaml
+rasaProServices:
+  database:
+    url: "postgresql://user:password@host:5432/dbname"
+```
+
+**From an existing secret** (recommended for production):
+
+Create a Kubernetes secret containing the database URL:
+
+```console
+kubectl create secret generic my-db-secret \
+  --from-literal=analyticsDbUrl="postgresql://user:password@host:5432/dbname"
+```
+
+Then reference it in your values:
+
+```yaml
+rasaProServices:
+  database:
+    urlExistingSecretName: my-db-secret
+    urlExistingSecretKey: analyticsDbUrl
+```
+
+When `urlExistingSecretName` is set it takes precedence over `url`.
+
+For AWS RDS IAM authentication, use `database.enableAwsRdsIam: true` together with `hostname`, `usernameExistingSecretName`/`username`, `databaseNameExistingSecretName`/`databaseName`, `port`, and `sslMode` instead of the URL fields.
+
 ### Use MiniO instead of S3
 
 To use MiniO instead of S3, set `AWS_ENDPOINT_URL` environment variable to the URL of the MiniO server along with `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. Also provide `AWS_REGION` and `BUCKET_NAME` environment variables.

--- a/charts/rasa/templates/helpers/_containers-env.tpl
+++ b/charts/rasa/templates/helpers/_containers-env.tpl
@@ -74,20 +74,20 @@ Environment Variables for Rasa Analytics
 - name: "RASA_ANALYTICS_DB_HOST_NAME"
   value: {{ .hostname | quote }}
 - name: "RASA_ANALYTICS_DB_NAME"
-  {{- if kindIs "map" .databaseName }}
+  {{- if .databaseNameExistingSecretName }}
   valueFrom:
     secretKeyRef:
-      name: {{ .databaseName.secretName | quote }}
-      key: {{ .databaseName.secretKey | quote }}
+      name: {{ .databaseNameExistingSecretName | quote }}
+      key: {{ .databaseNameExistingSecretKey | quote }}
   {{- else }}
   value: {{ .databaseName | quote }}
   {{- end }}
 - name: "RASA_ANALYTICS_DB_USERNAME"
-  {{- if kindIs "map" .username }}
+  {{- if .usernameExistingSecretName }}
   valueFrom:
     secretKeyRef:
-      name: {{ .username.secretName | quote }}
-      key: {{ .username.secretKey | quote }}
+      name: {{ .usernameExistingSecretName | quote }}
+      key: {{ .usernameExistingSecretKey | quote }}
   {{- else }}
   value: {{ .username | quote }}
   {{- end }}
@@ -99,11 +99,11 @@ Environment Variables for Rasa Analytics
   value: {{ .sslCaLocation | quote }}
 {{- else }}
 - name: "RASA_ANALYTICS_DB_URL"
-  {{- if kindIs "map" .url }}
+  {{- if .urlExistingSecretName }}
   valueFrom:
     secretKeyRef:
-      name: {{ .url.secretName | quote }}
-      key: {{ .url.secretKey | quote }}
+      name: {{ .urlExistingSecretName | quote }}
+      key: {{ .urlExistingSecretKey | quote }}
   {{- else }}
   value: {{ .url | quote }}
   {{- end }}

--- a/charts/rasa/values.yaml
+++ b/charts/rasa/values.yaml
@@ -414,27 +414,36 @@ rasaProServices:
     # -- database.enableAwsRdsIam specifies whether to use AWS RDS IAM authentication for the Rasa Pro Services container.
     enableAwsRdsIam: false
     # -- database.url specifies the URL of the data lake to store analytics data in. Use `hostname` if you use IAM authentication.
-    # It can be a plain string or a secret reference:
-    #   url:
-    #     secretName: my-secret
-    #     secretKey: analyticsDbUrl
+    # To pass the URL from an existing secret instead, leave this empty and set urlExistingSecretName and urlExistingSecretKey:
+    #   urlExistingSecretName: my-secret
+    #   urlExistingSecretKey: analyticsDbUrl
     url: ""
+    # -- database.urlExistingSecretName specifies the name of an existing secret containing the database URL. Takes precedence over `url` if set.
+    # urlExistingSecretName: ""
+    # -- database.urlExistingSecretKey specifies the key within the existing secret that holds the database URL.
+    # urlExistingSecretKey: ""
     # -- database.username specifies the username for the data lake to store analytics data in. Required if enableAwsRdsIam is true.
-    # It can be a plain string or a secret reference:
-    #   username:
-    #     secretName: my-secret
-    #     secretKey: analyticsDbUsername
+    # To pass the username from an existing secret instead, leave this empty and set usernameExistingSecretName and usernameExistingSecretKey:
+    #   usernameExistingSecretName: my-secret
+    #   usernameExistingSecretKey: analyticsDbUsername
     username: ""
+    # -- database.usernameExistingSecretName specifies the name of an existing secret containing the database username. Takes precedence over `username` if set.
+    # usernameExistingSecretName: ""
+    # -- database.usernameExistingSecretKey specifies the key within the existing secret that holds the database username.
+    # usernameExistingSecretKey: ""
     # -- database.hostname specifies the hostname of the data lake to store analytics data in. Required if enableAwsRdsIam is true.
     hostname: ""
     # -- database.port specifies the port for the data lake to store analytics data in. Required if enableAwsRdsIam is true.
     port: "5432"
     # -- database.databaseName specifies the database name for the data lake to store analytics data in. Required if enableAwsRdsIam is true.
-    # It can be a plain string or a secret reference:
-    #   databaseName:
-    #     secretName: my-secret
-    #     secretKey: analyticsDbName
+    # To pass the database name from an existing secret instead, leave this empty and set databaseNameExistingSecretName and databaseNameExistingSecretKey:
+    #   databaseNameExistingSecretName: my-secret
+    #   databaseNameExistingSecretKey: analyticsDbName
     databaseName: ""
+    # -- database.databaseNameExistingSecretName specifies the name of an existing secret containing the database name. Takes precedence over `databaseName` if set.
+    # databaseNameExistingSecretName: ""
+    # -- database.databaseNameExistingSecretKey specifies the key within the existing secret that holds the database name.
+    # databaseNameExistingSecretKey: ""
     # -- database.sslMode specifies the SSL mode for the data lake to store analytics data in. Required if enableAwsRdsIam is true.
     sslMode: ""
     # -- database.sslCaLocation specifies the SSL CA location for the data lake to store analytics data in. Required if sslMode is verify-full.


### PR DESCRIPTION
## Summary

- Replaces the broken `kindIs "map"` type detection pattern with explicit `*ExistingSecretName`/`*ExistingSecretKey` fields for `url`, `username`, and `databaseName` under `rasaProServices.database`
- The previous implementation caused secret values to be rendered as literal Go map strings (e.g. `map[secretKey:db_url secretName:rasa-db-secret-synced]`) instead of proper `secretKeyRef` entries in the pod spec
- Adds documentation in `README.md.gotmpl` with plain value and secret reference usage examples

## Test plan

- [ ] Deploy with `rasaProServices.database.url` set to a plain string — verify `RASA_ANALYTICS_DB_URL` env var has the literal value
- [ ] Deploy with `rasaProServices.database.urlExistingSecretName` and `urlExistingSecretKey` set — verify `kubectl describe pod` shows `<set to the key '...' in secret '...'>`
- [ ] Repeat for `usernameExistingSecretName`/`usernameExistingSecretKey` with `enableAwsRdsIam: true`
- [ ] Repeat for `databaseNameExistingSecretName`/`databaseNameExistingSecretKey` with `enableAwsRdsIam: true`
- [ ] Run `helm lint --strict charts/rasa`