### PR TITLE
feat(op-kits): add CNPG Database CR support for additional databases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,53 @@ Make sure to always check if `README.md` is valid and reflects your changes prop
 enabled: false
 ```
 
+## Commit Message Guidelines
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. The format is:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type | When to use | Version bump |
+|---|---|---|
+| `feat` | New feature or new value/template added to a chart | MINOR |
+| `fix` | Bug fix in a template, value default, or helper | PATCH |
+| `chore` | Version bumps, dependency updates, CI changes | PATCH |
+| `docs` | Changes to `README.md.gotmpl`, `CONTRIBUTING.md`, or inline comments | PATCH |
+| `refactor` | Template restructuring with no behaviour change | PATCH |
+| `BREAKING CHANGE` | Footer on any commit that changes existing default values or removes fields | MAJOR |
+
+### Scope
+
+Use the chart name as the scope: `rasa`, `studio`, or `op-kits`.
+
+### Examples
+
+```
+feat(op-kits): add CloudNativePG Database CR support for additional databases
+```
+```
+fix(rasa): correct ingress host template for action-server
+```
+```
+chore(studio): bump chart version to 2.5.0
+```
+```
+docs(op-kits): document Kafka external listener configuration
+```
+```
+feat(studio): add imagePullSecrets support to web-client component
+
+BREAKING CHANGE: renames webClient.image.pullPolicy to webClient.imagePullPolicy
+```
+
 This repository automatically release a new version of the Helm chart once new changes are merged. The only required steps are:
 
 1. Make the changes to the chart

--- a/charts/op-kits/Chart.yaml
+++ b/charts/op-kits/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: op-kits
 description: Operator Kits Helm Chart
 type: application
-version: 0.5.0-rc.0
+version: 0.5.0
 home: https://helm.rasa.com/
 sources:
   - https://helm.rasa.com/charts/op-kits

--- a/charts/op-kits/Chart.yaml
+++ b/charts/op-kits/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: op-kits
 description: Operator Kits Helm Chart
 type: application
-version: 0.4.2
+version: 0.5.0-rc.0
 home: https://helm.rasa.com/
 sources:
   - https://helm.rasa.com/charts/op-kits

--- a/charts/op-kits/README.md
+++ b/charts/op-kits/README.md
@@ -2,7 +2,7 @@
 
 Operator Kits Helm Chart
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0-rc.0](https://img.shields.io/badge/Version-0.5.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ You can install the chart from either the OCI registry or the GitHub Helm reposi
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.4.2
+$ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.5.0-rc.0
 ```
 
 ### Option 2: Install from GitHub Helm Repository
@@ -36,7 +36,7 @@ $ helm repo update
 Then install the chart:
 
 ```console
-$ helm install my-release rasa/op-kits --version 0.4.2
+$ helm install my-release rasa/op-kits --version 0.5.0-rc.0
 ```
 
 ## Uninstalling the Chart
@@ -58,13 +58,13 @@ You can pull the chart from either source:
 ### From OCI Registry:
 
 ```console
-$ helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.4.2
+$ helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.5.0-rc.0
 ```
 
 ### From GitHub Helm Repository:
 
 ```console
-$ helm pull rasa/op-kits --version 0.4.2
+$ helm pull rasa/op-kits --version 0.5.0-rc.0
 ```
 
 ## Operator Installation
@@ -141,13 +141,13 @@ Once operators are installed and running, you can deploy your application resour
 ```console
 # Option 1: Install from OCI Registry
 $ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits \
-    --version 0.4.2 \
+    --version 0.5.0-rc.0 \
     --namespace my-app-namespace \
     --create-namespace
 
 # Option 2: Install from GitHub Helm Repository (after adding the repo)
 $ helm install my-release rasa/op-kits \
-    --version 0.4.2 \
+    --version 0.5.0-rc.0 \
     --namespace my-app-namespace \
     --create-namespace
 ```
@@ -201,6 +201,7 @@ Based on the fullname, resources are named as follows:
 #### PostgreSQL (CloudNativePG)
 - **Cluster name**: `{fullname}-pg`
   - Override: Set `cloudnativepg.cluster.nameOverride`
+- **Database names**: taken directly from `cloudnativepg.databases.<key>.name`
 
 #### Kafka (Strimzi)
 - **Kafka cluster**: `{fullname}-kafka`
@@ -293,6 +294,41 @@ valkey:
       spec:
         storageClassName: "your-storage-class"  # Update this
 ```
+
+### PostgreSQL Additional Databases
+
+By default, the CloudNativePG `Cluster` creates one database (set via `cloudnativepg.cluster.bootstrap.initdb.database`). To create additional databases inside the same cluster, use the `cloudnativepg.databases` map. Each entry creates a separate `postgresql.cnpg.io/v1` `Database` CR managed by the CloudNativePG operator.
+
+```yaml
+cloudnativepg:
+  databases:
+    studioDb:
+      enabled: true
+      name: "studio"
+      owner: "appuser"
+    analyticsDb:
+      enabled: true
+      name: "analytics"
+      owner: "appuser"
+      encoding: "UTF8"
+      allowConnections: true
+      connectionLimit: -1
+```
+
+The `owner` must be a role that already exists in the cluster (e.g. the user created via `bootstrap.initdb.owner`). All databases automatically reference the cluster created by this chart release.
+
+Available fields per database entry:
+
+| Field | Required | Description |
+|---|---|---|
+| `enabled` | yes | Whether to create this Database CR |
+| `name` | yes | Database name in PostgreSQL |
+| `owner` | yes | PostgreSQL role that owns the database |
+| `encoding` | no | Character set encoding (e.g. `UTF8`) |
+| `tablespace` | no | Default tablespace for the database |
+| `allowConnections` | no | Whether the database can be connected to (default: `true`) |
+| `connectionLimit` | no | Max concurrent connections; `-1` means unlimited |
+| `isTemplate` | no | Whether the database is a template |
 
 ### Resource Configuration
 
@@ -695,6 +731,7 @@ strimzi:
 | cloudnativepg.cluster.resources | object | Resource limits and requests for PostgreSQL containers Example: resources:   limits:     cpu: "1"     memory: "1Gi"   requests:     cpu: "100m"     memory: "256Mi" | `{}` |
 | cloudnativepg.cluster.storage.size | string | Storage size for PostgreSQL data | `"15Gi"` |
 | cloudnativepg.cluster.storage.storageClass | string | Storage class name. Change to your storage class | `"gp2"` |
+| cloudnativepg.databases | object | Map of Database CRs to create inside the PostgreSQL cluster Each entry creates a separate postgresql.cnpg.io/v1 Database resource Example: databases:   studioDb:     enabled: true     name: "studio"     owner: "appuser"   rasaDb:     enabled: true     name: "rasa"     owner: "appuser"     encoding: "UTF8"     allowConnections: true     connectionLimit: -1 | `{}` |
 | cloudnativepg.enabled | bool | Enable CloudNativePG cluster deployment | `true` |
 | commonAnnotations | object | Additional annotations to apply to all resources Example: commonAnnotations:   monitoring.coreos.com/scrape: "true"   prometheus.io/port: "8080" | `{}` |
 | commonLabels | object | Additional labels to apply to all resources Example: commonLabels:   environment: production   team: platform | `{}` |

--- a/charts/op-kits/README.md
+++ b/charts/op-kits/README.md
@@ -2,7 +2,7 @@
 
 Operator Kits Helm Chart
 
-![Version: 0.5.0-rc.0](https://img.shields.io/badge/Version-0.5.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ You can install the chart from either the OCI registry or the GitHub Helm reposi
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.5.0-rc.0
+$ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.5.0
 ```
 
 ### Option 2: Install from GitHub Helm Repository
@@ -36,7 +36,7 @@ $ helm repo update
 Then install the chart:
 
 ```console
-$ helm install my-release rasa/op-kits --version 0.5.0-rc.0
+$ helm install my-release rasa/op-kits --version 0.5.0
 ```
 
 ## Uninstalling the Chart
@@ -58,13 +58,13 @@ You can pull the chart from either source:
 ### From OCI Registry:
 
 ```console
-$ helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.5.0-rc.0
+$ helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.5.0
 ```
 
 ### From GitHub Helm Repository:
 
 ```console
-$ helm pull rasa/op-kits --version 0.5.0-rc.0
+$ helm pull rasa/op-kits --version 0.5.0
 ```
 
 ## Operator Installation
@@ -141,13 +141,13 @@ Once operators are installed and running, you can deploy your application resour
 ```console
 # Option 1: Install from OCI Registry
 $ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits \
-    --version 0.5.0-rc.0 \
+    --version 0.5.0 \
     --namespace my-app-namespace \
     --create-namespace
 
 # Option 2: Install from GitHub Helm Repository (after adding the repo)
 $ helm install my-release rasa/op-kits \
-    --version 0.5.0-rc.0 \
+    --version 0.5.0 \
     --namespace my-app-namespace \
     --create-namespace
 ```

--- a/charts/op-kits/README.md.gotmpl
+++ b/charts/op-kits/README.md.gotmpl
@@ -200,6 +200,7 @@ Based on the fullname, resources are named as follows:
 #### PostgreSQL (CloudNativePG)
 - **Cluster name**: `{fullname}-pg`
   - Override: Set `cloudnativepg.cluster.nameOverride`
+- **Database names**: taken directly from `cloudnativepg.databases.<key>.name`
 
 #### Kafka (Strimzi)
 - **Kafka cluster**: `{fullname}-kafka`
@@ -292,6 +293,41 @@ valkey:
       spec:
         storageClassName: "your-storage-class"  # Update this
 ```
+
+### PostgreSQL Additional Databases
+
+By default, the CloudNativePG `Cluster` creates one database (set via `cloudnativepg.cluster.bootstrap.initdb.database`). To create additional databases inside the same cluster, use the `cloudnativepg.databases` map. Each entry creates a separate `postgresql.cnpg.io/v1` `Database` CR managed by the CloudNativePG operator.
+
+```yaml
+cloudnativepg:
+  databases:
+    studioDb:
+      enabled: true
+      name: "studio"
+      owner: "appuser"
+    analyticsDb:
+      enabled: true
+      name: "analytics"
+      owner: "appuser"
+      encoding: "UTF8"
+      allowConnections: true
+      connectionLimit: -1
+```
+
+The `owner` must be a role that already exists in the cluster (e.g. the user created via `bootstrap.initdb.owner`). All databases automatically reference the cluster created by this chart release.
+
+Available fields per database entry:
+
+| Field | Required | Description |
+|---|---|---|
+| `enabled` | yes | Whether to create this Database CR |
+| `name` | yes | Database name in PostgreSQL |
+| `owner` | yes | PostgreSQL role that owns the database |
+| `encoding` | no | Character set encoding (e.g. `UTF8`) |
+| `tablespace` | no | Default tablespace for the database |
+| `allowConnections` | no | Whether the database can be connected to (default: `true`) |
+| `connectionLimit` | no | Max concurrent connections; `-1` means unlimited |
+| `isTemplate` | no | Whether the database is a template |
 
 ### Resource Configuration
 

--- a/charts/op-kits/templates/cloudnativepg/database.yaml
+++ b/charts/op-kits/templates/cloudnativepg/database.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.cloudnativepg.enabled }}
+{{- range $name, $db := .Values.cloudnativepg.databases }}
+{{- if $db.enabled }}
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: {{ $db.name }}
+  namespace: {{ include "op-kits.namespace" $ }}
+  labels:
+    {{- include "op-kits.cloudnativepg.labels" $ | nindent 4 }}
+  {{- with $.Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  name: {{ $db.name }}
+  owner: {{ $db.owner }}
+  cluster:
+    name: {{ include "op-kits.cloudnativepg.clusterName" $ }}
+  {{- with $db.encoding }}
+  encoding: {{ . }}
+  {{- end }}
+  {{- with $db.tablespace }}
+  tablespace: {{ . }}
+  {{- end }}
+  {{- if hasKey $db "allowConnections" }}
+  allowConnections: {{ $db.allowConnections }}
+  {{- end }}
+  {{- if hasKey $db "connectionLimit" }}
+  connectionLimit: {{ $db.connectionLimit }}
+  {{- end }}
+  {{- if hasKey $db "isTemplate" }}
+  isTemplate: {{ $db.isTemplate }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/op-kits/values.yaml
+++ b/charts/op-kits/values.yaml
@@ -80,6 +80,24 @@ cloudnativepg:
     #     memory: "256Mi"
     resources: {}
 
+  # CloudNativePG Databases Configuration
+  # -- Map of Database CRs to create inside the PostgreSQL cluster
+  # Each entry creates a separate postgresql.cnpg.io/v1 Database resource
+  # Example:
+  # databases:
+  #   studioDb:
+  #     enabled: true
+  #     name: "studio"
+  #     owner: "appuser"
+  #   rasaDb:
+  #     enabled: true
+  #     name: "rasa"
+  #     owner: "appuser"
+  #     encoding: "UTF8"
+  #     allowConnections: true
+  #     connectionLimit: -1
+  databases: {}
+
 # Strimzi Kafka Configuration
 strimzi:
   # -- Enable Strimzi Kafka cluster deployment


### PR DESCRIPTION
## Summary                                                                                                                          
                                                                                                                                      
  - Adds `charts/op-kits/templates/cloudnativepg/database.yaml` — iterates over                                                       
    `cloudnativepg.databases` map and creates a `postgresql.cnpg.io/v1` `Database`                                                  
    CR per enabled entry, referencing the chart's managed cluster             
  - Adds `cloudnativepg.databases: {}` to `values.yaml` with commented examples                                                       
    and optional fields (`encoding`, `tablespace`, `allowConnections`,
    `connectionLimit`, `isTemplate`)                                                                                                  
  - Documents the feature in `README.md.gotmpl` with a field reference table and                                                      
    notes on read/write access via the `-rw` service endpoint                                                                         
                                                                                                                                      
  ## Test plan                                                                                                                        
                                                                                                                                      
  - [ ] `helm lint --strict charts/op-kits` passes                                                                                    
  - [ ] `helm template` with a populated `cloudnativepg.databases` map renders the                                                    
        expected `Database` CRs with correct `spec.cluster.name`                                                                    
  - [ ] Deploying to a cluster with CloudNativePG operator creates the databases                                                      
        inside the PostgreSQL cluster         
  - [ ] Superuser and owner role can read/write via the `-rw` service endpoint