### PR TITLE
docs(op-kits): update Valkey operator install to use OCI registry

### DIFF
--- a/charts/op-kits/Chart.yaml
+++ b/charts/op-kits/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: op-kits
 description: Operator Kits Helm Chart
 type: application
-version: 0.5.0
+version: 0.5.1
 home: https://helm.rasa.com/
 sources:
   - https://helm.rasa.com/charts/op-kits

--- a/charts/op-kits/README.md
+++ b/charts/op-kits/README.md
@@ -114,7 +114,7 @@ $ LATEST=$(curl -s https://api.github.com/repos/hyperspike/valkey-operator/relea
 
 # Install Valkey operator in valkey-operator-system namespace
 $ helm install valkey-operator \
-    --namespace valkey-operator-system \
+    --namespace valkey-system \
     --create-namespace \
     oci://ghcr.io/hyperspike/valkey-operator \
     --version ${LATEST}-chart
@@ -132,7 +132,7 @@ $ kubectl get pods -n cnpg-system
 $ kubectl get pods -n strimzi-system
 
 # Check Valkey operator
-$ kubectl get pods -n valkey-operator-system
+$ kubectl get pods -n valkey-system
 ```
 
 ### 5. Install Application Resources
@@ -165,10 +165,10 @@ $ helm uninstall cnpg-operator -n cnpg-system
 $ helm uninstall strimzi-operator -n strimzi-system
 
 # Remove Valkey operator
-$ helm uninstall valkey-operator -n valkey-operator-system
+$ helm uninstall valkey-operator -n valkey-system
 
 # Optionally remove the namespaces (only if empty)
-$ kubectl delete namespace cnpg-system strimzi-system valkey-operator-system
+$ kubectl delete namespace cnpg-system strimzi-system valkey-system
 ```
 
 > **Warning**: Removing operators will affect all PostgreSQL, Kafka, and Valkey clusters managed by them across the entire cluster.

--- a/charts/op-kits/README.md
+++ b/charts/op-kits/README.md
@@ -2,7 +2,7 @@
 
 Operator Kits Helm Chart
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ You can install the chart from either the OCI registry or the GitHub Helm reposi
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.5.0
+$ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.5.1
 ```
 
 ### Option 2: Install from GitHub Helm Repository
@@ -36,7 +36,7 @@ $ helm repo update
 Then install the chart:
 
 ```console
-$ helm install my-release rasa/op-kits --version 0.5.0
+$ helm install my-release rasa/op-kits --version 0.5.1
 ```
 
 ## Uninstalling the Chart
@@ -58,13 +58,13 @@ You can pull the chart from either source:
 ### From OCI Registry:
 
 ```console
-$ helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.5.0
+$ helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits --version 0.5.1
 ```
 
 ### From GitHub Helm Repository:
 
 ```console
-$ helm pull rasa/op-kits --version 0.5.0
+$ helm pull rasa/op-kits --version 0.5.1
 ```
 
 ## Operator Installation
@@ -106,17 +106,18 @@ $ helm install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operato
 
 ### 3. Valkey Operator
 
-Install the Valkey operator using the official Helm chart:
+Install the Valkey operator from the official OCI registry:
 
 ```console
-# Add the Hyperspike Helm repository
-$ helm repo add hyperspike https://charts.hyperspike.io
-$ helm repo update
+# Get the latest release version
+$ LATEST=$(curl -s https://api.github.com/repos/hyperspike/valkey-operator/releases/latest | jq -cr .tag_name)
 
-# Install Valkey operator in valkey-system namespace
-$ helm install valkey-operator hyperspike/valkey-operator \
-    --namespace valkey-system \
-    --create-namespace
+# Install Valkey operator in valkey-operator-system namespace
+$ helm install valkey-operator \
+    --namespace valkey-operator-system \
+    --create-namespace \
+    oci://ghcr.io/hyperspike/valkey-operator \
+    --version ${LATEST}-chart
 ```
 
 ### 4. Verify Operator Installation
@@ -131,7 +132,7 @@ $ kubectl get pods -n cnpg-system
 $ kubectl get pods -n strimzi-system
 
 # Check Valkey operator
-$ kubectl get pods -n valkey-system
+$ kubectl get pods -n valkey-operator-system
 ```
 
 ### 5. Install Application Resources
@@ -141,13 +142,13 @@ Once operators are installed and running, you can deploy your application resour
 ```console
 # Option 1: Install from OCI Registry
 $ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/op-kits \
-    --version 0.5.0 \
+    --version 0.5.1 \
     --namespace my-app-namespace \
     --create-namespace
 
 # Option 2: Install from GitHub Helm Repository (after adding the repo)
 $ helm install my-release rasa/op-kits \
-    --version 0.5.0 \
+    --version 0.5.1 \
     --namespace my-app-namespace \
     --create-namespace
 ```
@@ -164,10 +165,10 @@ $ helm uninstall cnpg-operator -n cnpg-system
 $ helm uninstall strimzi-operator -n strimzi-system
 
 # Remove Valkey operator
-$ helm uninstall valkey-operator -n valkey-system
+$ helm uninstall valkey-operator -n valkey-operator-system
 
 # Optionally remove the namespaces (only if empty)
-$ kubectl delete namespace cnpg-system strimzi-system valkey-system
+$ kubectl delete namespace cnpg-system strimzi-system valkey-operator-system
 ```
 
 > **Warning**: Removing operators will affect all PostgreSQL, Kafka, and Valkey clusters managed by them across the entire cluster.

--- a/charts/op-kits/README.md.gotmpl
+++ b/charts/op-kits/README.md.gotmpl
@@ -105,17 +105,18 @@ $ helm install strimzi-operator oci://quay.io/strimzi-helm/strimzi-kafka-operato
 
 ### 3. Valkey Operator
 
-Install the Valkey operator using the official Helm chart:
+Install the Valkey operator from the official OCI registry:
 
 ```console
-# Add the Hyperspike Helm repository
-$ helm repo add hyperspike https://charts.hyperspike.io
-$ helm repo update
+# Get the latest release version
+$ LATEST=$(curl -s https://api.github.com/repos/hyperspike/valkey-operator/releases/latest | jq -cr .tag_name)
 
-# Install Valkey operator in valkey-system namespace
-$ helm install valkey-operator hyperspike/valkey-operator \
-    --namespace valkey-system \
-    --create-namespace
+# Install Valkey operator in valkey-operator-system namespace
+$ helm install valkey-operator \
+    --namespace valkey-operator-system \
+    --create-namespace \
+    oci://ghcr.io/hyperspike/valkey-operator \
+    --version ${LATEST}-chart
 ```
 
 ### 4. Verify Operator Installation
@@ -130,7 +131,7 @@ $ kubectl get pods -n cnpg-system
 $ kubectl get pods -n strimzi-system
 
 # Check Valkey operator
-$ kubectl get pods -n valkey-system
+$ kubectl get pods -n valkey-operator-system
 ```
 
 ### 5. Install Application Resources
@@ -163,10 +164,10 @@ $ helm uninstall cnpg-operator -n cnpg-system
 $ helm uninstall strimzi-operator -n strimzi-system
 
 # Remove Valkey operator
-$ helm uninstall valkey-operator -n valkey-system
+$ helm uninstall valkey-operator -n valkey-operator-system
 
 # Optionally remove the namespaces (only if empty)
-$ kubectl delete namespace cnpg-system strimzi-system valkey-system
+$ kubectl delete namespace cnpg-system strimzi-system valkey-operator-system
 ```
 
 > **Warning**: Removing operators will affect all PostgreSQL, Kafka, and Valkey clusters managed by them across the entire cluster.

--- a/charts/op-kits/README.md.gotmpl
+++ b/charts/op-kits/README.md.gotmpl
@@ -113,7 +113,7 @@ $ LATEST=$(curl -s https://api.github.com/repos/hyperspike/valkey-operator/relea
 
 # Install Valkey operator in valkey-operator-system namespace
 $ helm install valkey-operator \
-    --namespace valkey-operator-system \
+    --namespace valkey-system \
     --create-namespace \
     oci://ghcr.io/hyperspike/valkey-operator \
     --version ${LATEST}-chart
@@ -131,7 +131,7 @@ $ kubectl get pods -n cnpg-system
 $ kubectl get pods -n strimzi-system
 
 # Check Valkey operator
-$ kubectl get pods -n valkey-operator-system
+$ kubectl get pods -n valkey-system
 ```
 
 ### 5. Install Application Resources
@@ -164,10 +164,10 @@ $ helm uninstall cnpg-operator -n cnpg-system
 $ helm uninstall strimzi-operator -n strimzi-system
 
 # Remove Valkey operator
-$ helm uninstall valkey-operator -n valkey-operator-system
+$ helm uninstall valkey-operator -n valkey-system
 
 # Optionally remove the namespaces (only if empty)
-$ kubectl delete namespace cnpg-system strimzi-system valkey-operator-system
+$ kubectl delete namespace cnpg-system strimzi-system valkey-system
 ```
 
 > **Warning**: Removing operators will affect all PostgreSQL, Kafka, and Valkey clusters managed by them across the entire cluster.


### PR DESCRIPTION
## Summary                                                            
            
  - Replace deprecated `hyperspike` Helm repo with official OCI registry (`oci://ghcr.io/hyperspike/valkey-operator`)
  - Update install namespace from `valkey-system` to `valkey-operator-system` to match upstream defaults                              
  - Add dynamic version resolution via GitHub releases API (`${LATEST}-chart`)                          
                                                                                                                                      
  ## Test plan                                                                                                                        
  - [x] Verify `pre-commit run --all-files` regenerates README.md cleanly
  - [x] Spot-check rendered README for correct install commands