### PR TITLE
feat(rasa): support raw YAML for endpoints/credentials via --set-file

### DIFF
--- a/.github/workflows/rasa-pro-release-candidate.yml
+++ b/.github/workflows/rasa-pro-release-candidate.yml
@@ -8,6 +8,7 @@ on:
       - charts/rasa/**
       - '!charts/studio/**'
       - '!charts/op-kits/**'
+  workflow_dispatch: {}
 
 jobs:
   release-candidate:

--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rasa
 description: A Rasa Pro Helm chart for Kubernetes
 type: application
-version: 2.2.0-rc.1
+version: 2.2.0-rc.0
 home: https://rasa.com
 sources:
   - https://github.com/RasaHQ/rasa-helm-charts/tree/main/charts/rasa

--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rasa
 description: A Rasa Pro Helm chart for Kubernetes
 type: application
-version: 2.2.0-rc.0
+version: 2.2.0
 home: https://rasa.com
 sources:
   - https://github.com/RasaHQ/rasa-helm-charts/tree/main/charts/rasa

--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rasa
 description: A Rasa Pro Helm chart for Kubernetes
 type: application
-version: 2.2.0-rc.0
+version: 2.2.0-rc.1
 home: https://rasa.com
 sources:
   - https://github.com/RasaHQ/rasa-helm-charts/tree/main/charts/rasa

--- a/charts/rasa/Chart.yaml
+++ b/charts/rasa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rasa
 description: A Rasa Pro Helm chart for Kubernetes
 type: application
-version: 2.1.0
+version: 2.2.0-rc.0
 home: https://rasa.com
 sources:
   - https://github.com/RasaHQ/rasa-helm-charts/tree/main/charts/rasa

--- a/charts/rasa/README.md
+++ b/charts/rasa/README.md
@@ -2,7 +2,7 @@
 
 A Rasa Pro Helm chart for Kubernetes
 
-![Version: 2.2.0-rc.0](https://img.shields.io/badge/Version-2.2.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.0-rc.1](https://img.shields.io/badge/Version-2.2.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -75,7 +75,7 @@ You can install the chart from either the OCI registry or the GitHub Helm reposi
 To install the chart with the release name `my-release`:
 
 ```console
-helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.2.0-rc.0
+helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.2.0-rc.1
 ```
 
 ### Option 2: Install from GitHub Helm Repository
@@ -90,7 +90,7 @@ helm repo update
 Then install the chart:
 
 ```console
-helm install my-release rasa/rasa --version 2.2.0-rc.0
+helm install my-release rasa/rasa --version 2.2.0-rc.1
 ```
 
 ## Upgrading the Chart
@@ -404,7 +404,7 @@ Helm CLI (`--set-file`):
 
 ```console
 helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa \
-  --version 2.2.0-rc.0 \
+  --version 2.2.0-rc.1 \
   --set-file rasa.settings.endpointsRaw=./endpoints.yml \
   --set-file rasa.settings.credentialsRaw=./credentials.yml
 ```
@@ -416,7 +416,7 @@ spec:
   sources:
     - repoURL: https://github.com/RasaHQ/rasa-helm-charts
       chart: rasa
-      targetRevision: 2.2.0-rc.0
+      targetRevision: 2.2.0-rc.1
       helm:
         fileParameters:
           - name: rasa.settings.endpointsRaw

--- a/charts/rasa/README.md
+++ b/charts/rasa/README.md
@@ -2,7 +2,7 @@
 
 A Rasa Pro Helm chart for Kubernetes
 
-![Version: 2.2.0-rc.1](https://img.shields.io/badge/Version-2.2.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.0-rc.0](https://img.shields.io/badge/Version-2.2.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -75,7 +75,7 @@ You can install the chart from either the OCI registry or the GitHub Helm reposi
 To install the chart with the release name `my-release`:
 
 ```console
-helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.2.0-rc.1
+helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.2.0-rc.0
 ```
 
 ### Option 2: Install from GitHub Helm Repository
@@ -90,7 +90,7 @@ helm repo update
 Then install the chart:
 
 ```console
-helm install my-release rasa/rasa --version 2.2.0-rc.1
+helm install my-release rasa/rasa --version 2.2.0-rc.0
 ```
 
 ## Upgrading the Chart
@@ -404,7 +404,7 @@ Helm CLI (`--set-file`):
 
 ```console
 helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa \
-  --version 2.2.0-rc.1 \
+  --version 2.2.0-rc.0 \
   --set-file rasa.settings.endpointsRaw=./endpoints.yml \
   --set-file rasa.settings.credentialsRaw=./credentials.yml
 ```
@@ -416,7 +416,7 @@ spec:
   sources:
     - repoURL: https://github.com/RasaHQ/rasa-helm-charts
       chart: rasa
-      targetRevision: 2.2.0-rc.1
+      targetRevision: 2.2.0-rc.0
       helm:
         fileParameters:
           - name: rasa.settings.endpointsRaw

--- a/charts/rasa/README.md
+++ b/charts/rasa/README.md
@@ -2,7 +2,7 @@
 
 A Rasa Pro Helm chart for Kubernetes
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.0-rc.0](https://img.shields.io/badge/Version-2.2.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -75,7 +75,7 @@ You can install the chart from either the OCI registry or the GitHub Helm reposi
 To install the chart with the release name `my-release`:
 
 ```console
-helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.1.0
+helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.2.0-rc.0
 ```
 
 ### Option 2: Install from GitHub Helm Repository
@@ -90,7 +90,7 @@ helm repo update
 Then install the chart:
 
 ```console
-helm install my-release rasa/rasa --version 2.1.0
+helm install my-release rasa/rasa --version 2.2.0-rc.0
 ```
 
 ## Upgrading the Chart
@@ -393,6 +393,42 @@ rasa:
 ```
 
 See the [Rasa channel documentation](https://rasa.com/docs/reference/channels/messaging-and-voice-channels) for all available channel configurations.
+
+#### Sourcing Endpoints and Credentials from Raw YAML Files
+
+In addition to the structured `rasa.settings.endpoints` and `rasa.settings.credentials` maps, the chart accepts the **raw contents of an `endpoints.yml` or `credentials.yml` file** via `rasa.settings.endpointsRaw` and `rasa.settings.credentialsRaw`. This lets the same file the developer uses locally for `rasa train` / `rasa run` flow directly into the rendered ConfigMap with no wrapper file or pre-commit step.
+
+When both the structured and raw values are provided, they are deep-merged. **The structured value wins on key conflicts** — this is intentional so infrastructure-owned blocks (e.g. `tracker_store`, `event_broker`) defined in `rasa.settings.endpoints` override the same keys in the raw file.
+
+Helm CLI (`--set-file`):
+
+```console
+helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa \
+  --version 2.2.0-rc.0 \
+  --set-file rasa.settings.endpointsRaw=./endpoints.yml \
+  --set-file rasa.settings.credentialsRaw=./credentials.yml
+```
+
+ArgoCD multi-source `Application` (referencing files from a values repo):
+
+```yaml
+spec:
+  sources:
+    - repoURL: https://github.com/RasaHQ/rasa-helm-charts
+      chart: rasa
+      targetRevision: 2.2.0-rc.0
+      helm:
+        fileParameters:
+          - name: rasa.settings.endpointsRaw
+            path: $values/endpoints.yml
+          - name: rasa.settings.credentialsRaw
+            path: $values/credentials.yml
+    - repoURL: https://github.com/your-org/your-app-repo
+      targetRevision: main
+      ref: values
+```
+
+`${VAR}` placeholders inside the raw file are preserved verbatim through the parse/merge/render pipeline, so Rasa's runtime environment-variable substitution continues to work.
 
 #### Configuring Endpoints
 
@@ -907,10 +943,12 @@ The following table lists all configurable parameters for this chart and their d
 | rasa.settings.authToken | object | settings.authToken references the Kubernetes Secret containing the static bearer token used to authenticate API requests. | `{"secretKey":"authToken","secretName":"rasa-secrets"}` |
 | rasa.settings.cors | string | settings.cors sets the allowed CORS origin for the Rasa API. Defaults to '*' (all origins). Restrict to specific domains in production. | `"*"` |
 | rasa.settings.credentials | object | settings.credentials enables credentials configuration for channel connectors # See: https://rasa.com/docs/reference/channels/messaging-and-voice-channels | `{}` |
+| rasa.settings.credentialsRaw | string | settings.credentialsRaw accepts a raw YAML string (e.g. the contents of a credentials.yml file) that is parsed and deep-merged with settings.credentials. The structured value wins on key conflicts. Intended for `helm install --set-file rasa.settings.credentialsRaw=./credentials.yml` or ArgoCD multi-source `fileParameters` referencing `$values/credentials.yml`. Leave unset/empty to disable. Malformed YAML fails the template render. | `""` |
 | rasa.settings.debugMode | bool | settings.debugMode enables debug mode | `false` |
 | rasa.settings.ducklingHttpUrl | string | settings.ducklingHttpUrl is the HTTP URL of the Duckling entity extraction service. Required when using Duckling for entity extraction. | `nil` |
 | rasa.settings.enableApi | bool | settings.enableApi enables the Rasa HTTP API in addition to the configured input channel. Required for most integrations. Supports token-based auth (authToken) or JWT auth (jwtSecret + jwtMethod). | `true` |
 | rasa.settings.endpoints | object | settings.endpoints enables endpoints configuration for the Rasa deployment. See: https://rasa.com/docs/pro/build/configuring-assistant#endpoints | `{}` |
+| rasa.settings.endpointsRaw | string | settings.endpointsRaw accepts a raw YAML string (e.g. the contents of an endpoints.yml file) that is parsed and deep-merged with settings.endpoints. The structured value wins on key conflicts, so infra-owned blocks (tracker_store, event_broker) defined in settings.endpoints take precedence over the same keys in the raw file. Intended for `helm install --set-file rasa.settings.endpointsRaw=./endpoints.yml` or ArgoCD multi-source `fileParameters` referencing `$values/endpoints.yml`. Leave unset/empty to disable. Malformed YAML fails the template render. | `""` |
 | rasa.settings.environment | string | settings.environment sets the Rasa runtime environment. Use 'production' to disable certain development-only defaults. | `"development"` |
 | rasa.settings.jwtMethod | string | settings.jwtMethod is JWT algorithm to be used | `"HS256"` |
 | rasa.settings.jwtSecret | object | settings.jwtSecret references the Kubernetes Secret containing the JWT secret used to verify signed tokens for API authentication. | `{"secretKey":"jwtSecret","secretName":"rasa-secrets"}` |

--- a/charts/rasa/README.md
+++ b/charts/rasa/README.md
@@ -2,7 +2,7 @@
 
 A Rasa Pro Helm chart for Kubernetes
 
-![Version: 2.2.0-rc.0](https://img.shields.io/badge/Version-2.2.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -75,7 +75,7 @@ You can install the chart from either the OCI registry or the GitHub Helm reposi
 To install the chart with the release name `my-release`:
 
 ```console
-helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.2.0-rc.0
+helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa --version 2.2.0
 ```
 
 ### Option 2: Install from GitHub Helm Repository
@@ -90,7 +90,7 @@ helm repo update
 Then install the chart:
 
 ```console
-helm install my-release rasa/rasa --version 2.2.0-rc.0
+helm install my-release rasa/rasa --version 2.2.0
 ```
 
 ## Upgrading the Chart
@@ -404,7 +404,7 @@ Helm CLI (`--set-file`):
 
 ```console
 helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/rasa \
-  --version 2.2.0-rc.0 \
+  --version 2.2.0 \
   --set-file rasa.settings.endpointsRaw=./endpoints.yml \
   --set-file rasa.settings.credentialsRaw=./credentials.yml
 ```
@@ -416,7 +416,7 @@ spec:
   sources:
     - repoURL: https://github.com/RasaHQ/rasa-helm-charts
       chart: rasa
-      targetRevision: 2.2.0-rc.0
+      targetRevision: 2.2.0
       helm:
         fileParameters:
           - name: rasa.settings.endpointsRaw

--- a/charts/rasa/README.md.gotmpl
+++ b/charts/rasa/README.md.gotmpl
@@ -393,6 +393,42 @@ rasa:
 
 See the [Rasa channel documentation](https://rasa.com/docs/reference/channels/messaging-and-voice-channels) for all available channel configurations.
 
+#### Sourcing Endpoints and Credentials from Raw YAML Files
+
+In addition to the structured `rasa.settings.endpoints` and `rasa.settings.credentials` maps, the chart accepts the **raw contents of an `endpoints.yml` or `credentials.yml` file** via `rasa.settings.endpointsRaw` and `rasa.settings.credentialsRaw`. This lets the same file the developer uses locally for `rasa train` / `rasa run` flow directly into the rendered ConfigMap with no wrapper file or pre-commit step.
+
+When both the structured and raw values are provided, they are deep-merged. **The structured value wins on key conflicts** — this is intentional so infrastructure-owned blocks (e.g. `tracker_store`, `event_broker`) defined in `rasa.settings.endpoints` override the same keys in the raw file.
+
+Helm CLI (`--set-file`):
+
+```console
+helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/{{ template "chart.name" . }} \
+  --version {{ template "chart.version" . }} \
+  --set-file rasa.settings.endpointsRaw=./endpoints.yml \
+  --set-file rasa.settings.credentialsRaw=./credentials.yml
+```
+
+ArgoCD multi-source `Application` (referencing files from a values repo):
+
+```yaml
+spec:
+  sources:
+    - repoURL: https://github.com/RasaHQ/rasa-helm-charts
+      chart: rasa
+      targetRevision: {{ template "chart.version" . }}
+      helm:
+        fileParameters:
+          - name: rasa.settings.endpointsRaw
+            path: $values/endpoints.yml
+          - name: rasa.settings.credentialsRaw
+            path: $values/credentials.yml
+    - repoURL: https://github.com/your-org/your-app-repo
+      targetRevision: main
+      ref: values
+```
+
+`${VAR}` placeholders inside the raw file are preserved verbatim through the parse/merge/render pipeline, so Rasa's runtime environment-variable substitution continues to work.
+
 #### Configuring Endpoints
 
 The `rasa.settings.endpoints` section allows you to configure various endpoints and integrations. These endpoints are written to the `endpoints.yml` file in the ConfigMap.

--- a/charts/rasa/templates/rasa/configmap.yaml
+++ b/charts/rasa/templates/rasa/configmap.yaml
@@ -1,4 +1,36 @@
 {{- if .Values.rasa.settings.mountDefaultConfigmap }}
+{{- /*
+Build the credentials map by deep-merging the structured value with the optional
+raw YAML string (credentialsRaw). The structured value wins on key conflicts.
+*/ -}}
+{{- $credentialsMerged := dict }}
+{{- if .Values.rasa.settings.credentialsRaw }}
+{{-   $rawTrim := .Values.rasa.settings.credentialsRaw | toString | trim }}
+{{-   if $rawTrim }}
+{{-     $parsed := fromYaml $rawTrim }}
+{{-     if hasKey $parsed "Error" }}
+{{-       fail (printf "rasa.settings.credentialsRaw: invalid YAML: %s" (index $parsed "Error")) }}
+{{-     end }}
+{{-     $credentialsMerged = $parsed }}
+{{-   end }}
+{{- end }}
+{{- if .Values.rasa.settings.credentials }}
+{{-   $credentialsMerged = merge (deepCopy .Values.rasa.settings.credentials) $credentialsMerged }}
+{{- end }}
+{{- $endpointsMerged := dict }}
+{{- if .Values.rasa.settings.endpointsRaw }}
+{{-   $rawTrim := .Values.rasa.settings.endpointsRaw | toString | trim }}
+{{-   if $rawTrim }}
+{{-     $parsed := fromYaml $rawTrim }}
+{{-     if hasKey $parsed "Error" }}
+{{-       fail (printf "rasa.settings.endpointsRaw: invalid YAML: %s" (index $parsed "Error")) }}
+{{-     end }}
+{{-     $endpointsMerged = $parsed }}
+{{-   end }}
+{{- end }}
+{{- if .Values.rasa.settings.endpoints }}
+{{-   $endpointsMerged = merge (deepCopy .Values.rasa.settings.endpoints) $endpointsMerged }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,12 +38,12 @@ metadata:
   labels:
     {{- include "rasa.labels" . | nindent 4 }}
 data:
-{{- with .Values.rasa.settings.credentials }}
+{{- if $credentialsMerged }}
   credentials: |
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $credentialsMerged | nindent 4 }}
 {{- end }}
-{{- with .Values.rasa.settings.endpoints }}
+{{- if $endpointsMerged }}
   endpoints: |
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $endpointsMerged | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/rasa/values.yaml
+++ b/charts/rasa/values.yaml
@@ -77,6 +77,13 @@ rasa:
       #   secret: "<SECRET>"
       #   page-access-token: "<PAGE-ACCESS-TOKEN>"
 
+    # -- settings.credentialsRaw accepts a raw YAML string (e.g. the contents of a credentials.yml file)
+    # that is parsed and deep-merged with settings.credentials. The structured value wins on key conflicts.
+    # Intended for `helm install --set-file rasa.settings.credentialsRaw=./credentials.yml`
+    # or ArgoCD multi-source `fileParameters` referencing `$values/credentials.yml`.
+    # Leave unset/empty to disable. Malformed YAML fails the template render.
+    credentialsRaw: ""
+
     # See: https://rasa.com/docs/rasa/telemetry/telemetry/
     telemetry:
       # -- telemetry.enabled allow Rasa to collect anonymous usage details
@@ -93,6 +100,15 @@ rasa:
       # models:
       #   url: http://my-server.com/models/default_core@latest
         # wait_time_between_pulls:  10   # [optional](default: 100)
+
+    # -- settings.endpointsRaw accepts a raw YAML string (e.g. the contents of an endpoints.yml file)
+    # that is parsed and deep-merged with settings.endpoints. The structured value wins on key conflicts,
+    # so infra-owned blocks (tracker_store, event_broker) defined in settings.endpoints take precedence
+    # over the same keys in the raw file.
+    # Intended for `helm install --set-file rasa.settings.endpointsRaw=./endpoints.yml`
+    # or ArgoCD multi-source `fileParameters` referencing `$values/endpoints.yml`.
+    # Leave unset/empty to disable. Malformed YAML fails the template render.
+    endpointsRaw: ""
 
       # --endpoints.action_endpoint is a server which runs your custom actions.
       # See: https://rasa.com/docs/reference/integrations/action-server/actions


### PR DESCRIPTION
## Summary                                                                                                                          
                                                                              
  - Add optional `rasa.settings.endpointsRaw` and `rasa.settings.credentialsRaw` string values that accept the raw contents of an     
  `endpoints.yml` / `credentials.yml` file (via `helm install --set-file` or ArgoCD `fileParameters`)                                 
  - Deep-merge the parsed raw values with the existing structured `rasa.settings.endpoints` / `rasa.settings.credentials` maps;
  **structured wins on key conflicts** so infra-owned blocks (`tracker_store`, `event_broker`) override the same keys in the app-owned
   raw file                                                                                                                           
  - Bump chart to `2.2.0-rc.0` (RC — needs e2e validation before promoting)   
                                                                                                                                      
  ## Why                                                                                                                              
                                                                              
  Apps consumed by ArgoCD ApplicationSet carry `endpoints.yml` / `credentials.yml` at the app-repo root — the same files developers   
  use for local `rasa train` / `rasa run`. Today the chart only accepts structured maps, forcing teams to maintain a parallel wrapper 
  file or a pre-commit step. This change makes the local file the single source of truth that flows directly into the rendered       
  ConfigMap, while still letting infra override sensitive blocks centrally.                                                           
                                                                           
  ## Behaviour                                                                
              
  | Scenario | Result |
  |---|---|            
  | Only `endpoints` set | Unchanged from today |
  | Only `endpointsRaw` set | ConfigMap contains parsed file content |
  | Both set, disjoint keys | Union of both |                                                                                         
  | Both set, overlapping key | Structured wins; raw's value dropped for that key |
  | `endpointsRaw` whitespace-only | Treated as unset |                                                                               
  | `endpointsRaw` malformed YAML | Template render fails with explicit error |                                                       
                                                                                                                                      
  `${VAR}` placeholders survive the `fromYaml → merge → toYaml` round-trip verbatim, so Rasa's runtime env-var substitution continues 
  to work.                                                                                                                            
                                                                                                                                      
  Same matrix applies to `credentials` / `credentialsRaw`.                                                                            
                                                                                                                                      
  Fully backward-compatible — no rename, no default change.                   
                                                                                                                                      
  ## Test plan                                                            
  - [x] `helm lint --strict charts/rasa` clean                                                                                        
  - [x] `helm template` validated against all six scenarios above         
  - [x] Deploy `2.2.0-rc.0` to a non-prod cluster via ArgoCD with `fileParameters` referencing a real `endpoints.yml`                 
  - [x] Confirm rendered ConfigMap mounts correctly and Rasa starts                                                                   
  - [x] Confirm env-var substitution works for `${VAR}` references in the raw file                                                    
  - [x] Promote to `2.2.0` (drop `-rc.0`) before merging to `main`