### PR TITLE
feat(studio)!: split keycloak clientId into frontend/backend client IDs

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Rasa Studio Helm chart for Kubernetes
 type: application
-version: 2.4.2
+version: 3.0.0-rc.0
 home: https://helm.rasa.com
 sources:
   - https://github.com/RasaHQ/rasa-helm-charts/tree/main/charts/studio

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -2,7 +2,7 @@
 
 A Rasa Studio Helm chart for Kubernetes
 
-![Version: 2.4.2](https://img.shields.io/badge/Version-2.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.0-rc.0](https://img.shields.io/badge/Version-3.0.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Architecture
 
@@ -70,7 +70,7 @@ You can install the chart from either the OCI registry or the GitHub Helm reposi
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/studio --version 2.4.2
+$ helm install my-release oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/studio --version 3.0.0-rc.0
 ```
 
 ### Option 2: Install from GitHub Helm Repository
@@ -85,7 +85,7 @@ $ helm repo update
 Then install the chart:
 
 ```console
-$ helm install my-release rasa/studio --version 2.4.2
+$ helm install my-release rasa/studio --version 3.0.0-rc.0
 ```
 
 ## Quick Start
@@ -137,13 +137,13 @@ You can pull the chart from either source:
 ### From OCI Registry:
 
 ```console
-$ helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/studio --version 2.4.2
+$ helm pull oci://europe-west3-docker.pkg.dev/rasa-releases/helm-charts/studio --version 3.0.0-rc.0
 ```
 
 ### From GitHub Helm Repository:
 
 ```console
-$ helm pull rasa/studio --version 2.4.2
+$ helm pull rasa/studio --version 3.0.0-rc.0
 ```
 
 ## General Configuration
@@ -596,13 +596,14 @@ Check the [chart changelog](https://github.com/RasaHQ/rasa-helm-charts/releases)
 | config.ingressAnnotations | object | Define the ingress annotations to be used for ALL the ingress resources. These annotations will be applied to all ingress resources created by this chart. Example:   kubernetes.io/ingress.class: nginx   cert-manager.io/cluster-issuer: letsencrypt-prod | `{}` |
 | config.ingressClassName | string | Define the ingress class name to be used for ALL the ingress resources. This value will be applied to all ingress resources created by this chart. Example: "nginx", "istio", "traefik" Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class | `""` |
 | config.ingressHost | string | Defines the host name for all Studio ingress resources. This value is used as an anchor (&dns_hostname) for referencing the host name across multiple places in the Helm chart. WARNING: Do NOT delete or modify the anchor (&dns_hostname) as it is critical for the proper functioning of the chart. If you need to update the host name, only change the value (INGRESS.HOST.NAME), keeping the anchor intact. | `"INGRESS.HOST.NAME"` |
-| config.keycloak | object | config.keycloak defines the Keycloak configuration settings. This section configures the authentication and authorization service. | `{"adminPassword":{"secretKey":"KEYCLOAK_ADMIN_PASSWORD","secretName":"studio-secrets"},"adminUsername":"kcadmin","apiClientId":"admin-cli","apiPassword":{"secretKey":"KEYCLOAK_API_PASSWORD","secretName":"studio-secrets"},"apiUsername":"realmadmin","clientId":"rasa-studio-backend","realm":"rasa-studio","url":""}` |
+| config.keycloak | object | config.keycloak defines the Keycloak configuration settings. This section configures the authentication and authorization service. | `{"adminPassword":{"secretKey":"KEYCLOAK_ADMIN_PASSWORD","secretName":"studio-secrets"},"adminUsername":"kcadmin","apiClientId":"admin-cli","apiPassword":{"secretKey":"KEYCLOAK_API_PASSWORD","secretName":"studio-secrets"},"apiUsername":"realmadmin","backendClientId":"rasa-studio-backend","frontendClientId":"rasa-studio-frontend","realm":"rasa-studio","url":""}` |
 | config.keycloak.adminPassword | object | config.keycloak.adminPassword defines the admin password for Keycloak. This password is used to login to the Keycloak admin console. The password is stored in a Kubernetes secret. | `{"secretKey":"KEYCLOAK_ADMIN_PASSWORD","secretName":"studio-secrets"}` |
 | config.keycloak.adminUsername | string | config.keycloak.adminUsername is the admin username for Keycloak. This username is used to login to the Keycloak admin console. | `"kcadmin"` |
 | config.keycloak.apiClientId | string | config.keycloak.apiClientId is the client ID for Keycloak API. This client is used by Studio Backend to authenticate with Keycloak. | `"admin-cli"` |
 | config.keycloak.apiPassword | object | config.keycloak.apiPassword is the password for Keycloak API. This password is used by Studio Backend to authenticate with Keycloak. | `{"secretKey":"KEYCLOAK_API_PASSWORD","secretName":"studio-secrets"}` |
 | config.keycloak.apiUsername | string | config.keycloak.apiUsername is the username for Keycloak API. This username is used by Studio Backend to authenticate with Keycloak. | `"realmadmin"` |
-| config.keycloak.clientId | string | config.keycloak.clientId is the client ID for Keycloak. This client is used by Studio to authenticate with Keycloak. | `"rasa-studio-backend"` |
+| config.keycloak.backendClientId | string | config.keycloak.backendClientId is the client ID used by the Studio backend to authenticate with Keycloak. | `"rasa-studio-backend"` |
+| config.keycloak.frontendClientId | string | config.keycloak.frontendClientId is the client ID used by the Studio frontend to authenticate with Keycloak. | `"rasa-studio-frontend"` |
 | config.keycloak.realm | string | config.keycloak.realm is the realm name for Keycloak. This realm is used by Studio to manage users and clients. | `"rasa-studio"` |
 | config.keycloak.url | string | config.keycloak.url overrides the default service endpoint for Keycloak. Format is `http(s)://<ingressHost>/auth`. Required only if your cluster redirects internal HTTP traffic to HTTPS. | `""` |
 | config.nodeSelector | object | Common pod scheduling configuration for all deployments. These settings can be overridden by component-specific configurations. Not possible to combine with component-specific configurations for each scheduling option. | `{}` |

--- a/charts/studio/templates/studio/_env.tpl
+++ b/charts/studio/templates/studio/_env.tpl
@@ -74,8 +74,8 @@ Backend Keycloak env
 {{- with .Values.config.keycloak }}
 - name: KEYCLOAK_REALM
   value: {{ .realm | quote }}
-- name: KEYCLOAK_CLIENT_ID
-  value: {{ .clientId | quote }}
+- name: KEYCLOAK_BACKEND_CLIENT_ID
+  value: {{ .backendClientId | quote }}
 - name: KEYCLOAK_API_CLIENT_ID
   value: {{ .apiClientId | quote }}
 - name: KEYCLOAK_API_USERNAME

--- a/charts/studio/templates/studio/web-client/configmap.yaml
+++ b/charts/studio/templates/studio/web-client/configmap.yaml
@@ -7,7 +7,7 @@ data:
     window.API_ENDPOINT = "{{ .Values.config.connectionType }}://{{ if .Values.backend.ingress.hostName }}{{ .Values.backend.ingress.hostName }}{{ else }}{{ .Values.config.ingressHost }}{{ end }}/api";
     window.KEYCLOAK_URL = "{{ .Values.config.connectionType }}://{{ if .Values.keycloak.ingress.hostName }}{{ .Values.keycloak.ingress.hostName }}{{ else }}{{ .Values.config.ingressHost }}{{ end }}/auth";
     window.KEYCLOAK_REALM = {{ .Values.config.keycloak.realm | quote }};
-    window.KEYCLOAK_CLIENT_ID = {{ .Values.config.keycloak.clientId | quote }};
+    window.KEYCLOAK_CLIENT_ID = {{ .Values.config.keycloak.frontendClientId | quote }};
     window.VOICE_INSPECTOR_ENABLED = {{ .Values.webClient.environmentVariables.VOICE_INSPECTOR_ENABLED | quote | default "false" }};
     window.SILENCE_TIMEOUT_ENABLED = {{ .Values.webClient.environmentVariables.SILENCE_TIMEOUT_ENABLED | quote | default "false" }};
     window.EDIT_SYSTEM_RESPONSES_ENABLED = {{ .Values.webClient.environmentVariables.EDIT_SYSTEM_RESPONSES_ENABLED | quote | default "false" }};

--- a/charts/studio/values.schema.json
+++ b/charts/studio/values.schema.json
@@ -286,7 +286,11 @@
               "description": "Keycloak realm name",
               "type": "string"
             },
-            "clientId": {
+            "frontendClientId": {
+              "description": "Keycloak client ID for Studio frontend",
+              "type": "string"
+            },
+            "backendClientId": {
               "description": "Keycloak client ID for Studio backend",
               "type": "string"
             },

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -114,9 +114,10 @@ config:
     # -- config.keycloak.realm is the realm name for Keycloak.
     # This realm is used by Studio to manage users and clients.
     realm: "rasa-studio"
-    # -- config.keycloak.clientId is the client ID for Keycloak.
-    # This client is used by Studio to authenticate with Keycloak.
-    clientId: "rasa-studio-backend"
+    # -- config.keycloak.frontendClientId is the client ID used by the Studio frontend to authenticate with Keycloak.
+    frontendClientId: "rasa-studio-frontend"
+    # -- config.keycloak.backendClientId is the client ID used by the Studio backend to authenticate with Keycloak.
+    backendClientId: "rasa-studio-backend"
     # -- config.keycloak.apiClientId is the client ID for Keycloak API.
     # This client is used by Studio Backend to authenticate with Keycloak.
     apiClientId: "admin-cli"


### PR DESCRIPTION
The single config.keycloak.clientId was used for both the Studio backend (env var) and the web client (window var). Splitting them lets each component authenticate against its own Keycloak client. Also adds a migration check that fails helm install/upgrade with a clear hint if the deprecated clientId is set.

BREAKING CHANGE: config.keycloak.clientId is removed. Use backendClientId and frontendClientId instead. The backend env var KEYCLOAK_CLIENT_ID was renamed to KEYCLOAK_BACKEND_CLIENT_ID — the Studio backend image must support this name.